### PR TITLE
allow media file to be used as a logo

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -9,7 +9,7 @@
 $conf['sb_pagename'] = 'navigation';    // the pagename for the navigation pages
 $conf['sb_position'] = 'left';
 $conf['ft_pagename'] = 'footer';        // the pagename for the footer page
-$conf['closedwiki']  = false;           // set to true if you run a closed wiki 
-$conf['logo']        = false;           // path to an image used as logo
+$conf['closedwiki']  = 0;               // set to true if you run a closed wiki
+$conf['logo']        = '';              // path to an image used as logo
 $conf['opengraphheading'] = 1;          // add opengraph namespace prefixes to head section
- 
+

--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -50,17 +50,17 @@ function dokubook_tpl_logo() {
                 $logo = ml($logo, array('w' => 128));
             }
             break;
-        case(@file_exists(DOKU_TPLINC.'images/logo.jpg')):
-            $logo = DOKU_TPL.'images/logo.jpg';
+        case(@file_exists(tpl_incdir().'images/logo.jpg')):
+            $logo = tpl_basedir().'images/logo.jpg';
             break;
-        case(@file_exists(DOKU_TPLINC.'images/logo.jpeg')):
-            $logo = DOKU_TPL.'images/logo.jpeg';
+        case(@file_exists(tpl_incdir().'images/logo.jpeg')):
+            $logo = tpl_basedir().'images/logo.jpeg';
             break;
-        case(@file_exists(DOKU_TPLINC.'images/logo.png')):
-            $logo = DOKU_TPL.'images/logo.png';
+        case(@file_exists(tpl_incdir().'images/logo.png')):
+            $logo = tpl_basedir().'images/logo.png';
             break;
         default:
-            $logo = DOKU_TPL.'images/dokuwiki-128.png';
+            $logo = tpl_basedir().'images/dokuwiki-128.png';
             break;
     }
 

--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -39,12 +39,16 @@ function html_list_index_navigation($item){
  */
 function dokubook_tpl_logo() {
     global $conf;
-    
+
     $out = '';
 
     switch(true) {
         case(tpl_getConf('logo')):
-            $logo = tpl_getconf('logo');
+            $logo = tpl_getConf('logo');
+            // check if configured logo is a media file
+            if(file_exists(mediaFN($logo))) {
+                $logo = ml($logo, array('w' => 128));
+            }
             break;
         case(@file_exists(DOKU_TPLINC.'images/logo.jpg')):
             $logo = DOKU_TPL.'images/logo.jpg';


### PR DESCRIPTION
If the configured logo is a valid media file ID, the correct URL to use
it is generated including resizing it to the proper width.

This also fixes the default values in conf (booleans have to be numeric
in DokuWiki conf and strings should default to empty string)