### PR TITLE
change messages and translations

### DIFF
--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -3,5 +3,5 @@
  * German Language file for DokuBook template
  */
 
-$lang['toolbox']    = 'toolbox';
+$lang['toolbox']    = 'werkzeuge';
 $lang['navigation'] = 'navigation';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -3,5 +3,5 @@
  * English Language file for DokuBook template
  */
 
-$lang['toolbox']    = 'toolbox';
+$lang['toolbox']    = 'tools';
 $lang['navigation'] = 'navigation';

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -4,4 +4,4 @@
  */
 
 $lang['toolbox']    = 'herramientas';
-$lang['navigation'] = 'menú';
+$lang['navigation'] = 'navegación';

--- a/lang/es/settings.php
+++ b/lang/es/settings.php
@@ -5,7 +5,7 @@
  * @author:     Esteban De La Fuente Rubio <esteban[at]delaf.cl>
  */
 
-$lang['sb_pagename'] = "Página para usar como menú";
+$lang['sb_pagename'] = "Página para usar como navegación";
 $lang['sb_position'] = "Posición de la barra de navegación lateral";
 $lang['ft_pagename'] = "Página para ser usada como pie de página";
 $lang['closedwiki']  = "Wiki cerrado (barra de navegación lateral muestra solo el enlace para ingresar al wiki)";

--- a/lang/ko/lang.php
+++ b/lang/ko/lang.php
@@ -3,5 +3,5 @@
  * Korean Language file for DokuBook template
  */
 
-$lang['toolbox']    = '도구모음';
+$lang['toolbox']    = '도구';
 $lang['navigation'] = '둘러보기';


### PR DESCRIPTION
In MediaWiki, 'Toolbox' is renamed to 'Tools'. For more infomation, see page https://phabricator.wikimedia.org/T56910 . And in DokuWiki, 'Index' is changed as 'Sitemap', so I change 'Site index' to 'Sitemap'.
